### PR TITLE
Fix for PDF metadata in details view

### DIFF
--- a/ui/app/detail/detail.controller.js
+++ b/ui/app/detail/detail.controller.js
@@ -72,7 +72,7 @@
               metaCount++;
               ctrl.hasMeta = true;
             }
-            var metaName = i18n[metaEl.getAttribute('name')] || metaEl.getAttribute('name')
+            var metaName = i18n[metaEl.getAttribute('name')] || metaEl.getAttribute('name') || metaEl.getAttribute('http-equiv')
               .replace(/([a-z])([A-Z])/g, '$1 $2')
               .replace(/(\-|\_)/g, ' ');
             metaObj[metaName] = metaEl.getAttribute('content') || ' ';


### PR DESCRIPTION
After loading a PDF, the PDF details page wouldn't load as one metadata element didn't have a "name" attribute, but rather an "http-equiv" attribute. 
