### PR TITLE
Removing old dependencies that were needed for analytics dashboard

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,15 +19,9 @@
     "ng-json-explorer": "8c2a0f9104",
     "ng-sortable": "^1.3.3",
     "vkbeautify-wrapper": "*",
-    "angular-resource": "~1.5.3",
-    "angular-route": "~1.5.3",
-    "angular-sanitize": "~1.5.3",
-    "ng-table": "~0.8.3",
-    "angular-recursion": "~1.0.5",
     "highcharts": "^4.2",
     "ml-highcharts-ng": ">=0.0.11",
     "angular-google-maps": "^2.2",
-    "angular-ui-sortable": "^0.14.0",
     "ml-google-maps-ng": "^0.0.1",
     "angular-color-picker": "^1.0.10",
     "ml-analytics-dashboard-ng": "^2.2.1"
@@ -50,7 +44,6 @@
     "angular": "~1.5.3",
     "angular-bootstrap": "^1.1",
     "lodash": "~4.5.1",
-    "highcharts": "^4.2",
-    "angular-ui-sortable": "^0.14.0"
+    "highcharts": "^4.2"
   }
 }

--- a/ui/app/app.js
+++ b/ui/app/app.js
@@ -18,11 +18,6 @@
     'app.user',
     'ui.bootstrap',
     'ui.router',
-    'ngRoute',
-    'ngResource',
-    'ngSanitize',
-    'ui.dashboard',
-    'ngTable',
     'ml.google-maps',
     'ml.analyticsDashboard'
   ]);

--- a/ui/index.html
+++ b/ui/index.html
@@ -13,7 +13,6 @@
     <link rel="stylesheet" href="/bower_components/highlightjs/styles/default.css" />
     <link rel="stylesheet" href="/bower_components/ng-json-explorer/dist/angular-json-explorer.css" />
     <link rel="stylesheet" href="/bower_components/ng-sortable/dist/ng-sortable.css" />
-    <link rel="stylesheet" href="/bower_components/ng-table/dist/ng-table.min.css" />
     <link rel="stylesheet" href="/bower_components/ml-google-maps-ng/dist/ml-google-maps-ng.css" />
     <link rel="stylesheet" href="/bower_components/angular-color-picker/angular-color-picker.css" />
     <link rel="stylesheet" href="/bower_components/malhar-angular-dashboard/dist/malhar-angular-dashboard.css" />
@@ -57,11 +56,6 @@
     <script src="/bower_components/ng-json-explorer/dist/angular-json-explorer.js"></script>
     <script src="/bower_components/ng-sortable/dist/ng-sortable.js"></script>
     <script src="/bower_components/vkbeautify-wrapper/dist/vkbeautify.0.99.00.beta.js"></script>
-    <script src="/bower_components/angular-resource/angular-resource.js"></script>
-    <script src="/bower_components/angular-route/angular-route.js"></script>
-    <script src="/bower_components/angular-sanitize/angular-sanitize.js"></script>
-    <script src="/bower_components/ng-table/dist/ng-table.min.js"></script>
-    <script src="/bower_components/angular-recursion/angular-recursion.js"></script>
     <script src="/bower_components/highcharts/highcharts.js"></script>
     <script src="/bower_components/highcharts/highcharts-more.js"></script>
     <script src="/bower_components/highcharts/modules/exporting.js"></script>
@@ -75,12 +69,13 @@
     <script src="/bower_components/google-maps-utility-library-v3-keydragzoom/dist/keydragzoom.js"></script>
     <script src="/bower_components/js-rich-marker/src/richmarker.js"></script>
     <script src="/bower_components/angular-google-maps/dist/angular-google-maps.js"></script>
-    <script src="/bower_components/jquery-ui/jquery-ui.js"></script>
-    <script src="/bower_components/angular-ui-sortable/sortable.js"></script>
     <script src="/bower_components/angular-ui-utils/ui-utils.js"></script>
     <script src="/bower_components/angular-ui-map/ui-map.js"></script>
     <script src="/bower_components/ml-google-maps-ng/dist/ml-google-maps-ng.js"></script>
     <script src="/bower_components/angular-color-picker/angular-color-picker.js"></script>
+    <script src="/bower_components/angular-recursion/angular-recursion.js"></script>
+    <script src="/bower_components/jquery-ui/jquery-ui.js"></script>
+    <script src="/bower_components/angular-ui-sortable/sortable.js"></script>
     <script src="/bower_components/malhar-angular-dashboard/dist/malhar-angular-dashboard.js"></script>
     <script src="/bower_components/ml-analytics-dashboard-ng/dist/ml-analytics-dashboard-ng.js"></script>
     <script src="/bower_components/ml-analytics-dashboard-ng/dist/ml-analytics-dashboard-ng-templates.js"></script>


### PR DESCRIPTION
But these are now either included in ml-analytics-dashboard-ng - or have
been eliminated from that project.

I searched the code and manually tested a fresh installation. I'm not
100% sure this didn't introduce any bugs, but I'm fairly certain. ;-)